### PR TITLE
Refactors Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 /tests/a.out
 /build
+/.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ Unit tests are in `tests/unit/<file.t.cpp>` and use the
 - `is_union` used builtin `__is_union(Type)`.  ditto.
 - `is_nothrow_constructible` used builtin `__is_nothrow_constructible(Type, Args...)`.  ditto
 
+## ToDo
+
+### Unit tests
+
+- [ ] `vector::shrink_to_fit()`

--- a/README.md
+++ b/README.md
@@ -40,4 +40,9 @@ Unit tests are in `tests/unit/<file.t.cpp>` and use the
 
 ### Unit tests
 
+Need the following unit tests to be written:
+
+- [ ] `vector::vector((vector&& other, const Allocator& alloc)`
 - [ ] `vector::shrink_to_fit()`
+- [ ] `vector::reserve()` 
+- [ ] `vector::::operator=(vector&& other) noexcept` when different

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ a little bit of C++-20.  There's no attempt to be portable or backward
 compatible beyond following good practices.  There's no obfuscating
 names with `__` to avoid conflicts with other code.
 
-Ideally, no `std` code is used.  However, `<limits>` and
-`<stdexcept>` are used from `std` because it seems like a lot of work
-for not much gain.
+Ideally, no `std` code is used (see exceptions below).
 
 The namespace is `pw` and include files are `pw/<name>`.  Most of
 the actual implementations are in `pw/impl/<file.h>`.  In fact,
@@ -28,4 +26,13 @@ code.
 
 Unit tests are in `tests/unit/<file.t.cpp>` and use the
 [catch2](https://github.com/catchorg/Catch2) framework.
+
+## Things I didn't implement
+
+- `<limits>` and `<stdexcept>` are used from `std` because it seems like a lot of work
+  for not much gain.
+- `std::initializer_list` is inherently a compiler builtin struct
+- `is_class` used builtin `__is_class(Type)`.  Because I couldn't implement a working version.
+- `is_union` used builtin `__is_union(Type)`.  ditto.
+- `is_nothrow_constructible` used builtin `__is_nothrow_constructible(Type, Args...)`.  ditto
 

--- a/pw/impl/CMakeLists.txt
+++ b/pw/impl/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(pw-impl INTERFACE
     equal.h
     exchange.h
     fill.h
+    fill_n.h
     for_each.h
     forward.h
     integral_constant.h

--- a/pw/impl/add_rvalue_reference.h
+++ b/pw/impl/add_rvalue_reference.h
@@ -1,0 +1,7 @@
+#ifndef INCLUDED_PW_IMPL_ADD_RVALUE_REFERENCE_H
+#define INCLUDED_PW_IMPL_ADD_RVALUE_REFERENCE_H
+
+namespace pw {
+} // namespace pw
+
+#endif /* INCLUDED_PW_IMPL_ADD_RVALUE_REFERENCE_H */

--- a/pw/impl/back_insert_iterator.h
+++ b/pw/impl/back_insert_iterator.h
@@ -31,6 +31,7 @@ protected:
 
 template<class Container>
 back_insert_iterator<Container>::back_insert_iterator(container_type& container)
+    : m_container(&container)
 {
 }
 

--- a/pw/impl/copy.h
+++ b/pw/impl/copy.h
@@ -9,7 +9,7 @@ copy(InputIterator begin, InputIterator end, OutputIterator dest)
 {
     while (begin != end)
     {
-        *dest = *begin++;
+        *dest++ = *begin++;
     }
     return dest;
 }

--- a/pw/impl/fill_n.h
+++ b/pw/impl/fill_n.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDED_PW_IMPL_FILL_N_H
+#define INCLUDED_PW_IMPL_FILL_N_H
+
+namespace pw {
+template<class Iterator, class Size, class Type>
+constexpr Iterator
+fill_n(Iterator first, Size count, const Type& value)
+{
+    for (Size i = 0; i < count; ++i)
+    {
+        *first++ = value;
+    }
+    return first;
+}
+
+} // namespace pw
+#endif /* INCLUDED_PW_IMPL_FILL_N_H */

--- a/pw/impl/is_move_constructible.h
+++ b/pw/impl/is_move_constructible.h
@@ -1,0 +1,18 @@
+#ifndef INCLUDED_PW_IMPL_IS_MOVE_CONSTRUCTIBLE_H
+#define INCLUDED_PW_IMPL_IS_MOVE_CONSTRUCTIBLE_H
+
+#include <pw/impl/integral_constant.h>
+
+namespace pw {
+
+template<class Type, class... Args>
+struct is_nothrow_constructible : public integral_constant<bool, __is_nothrow_constructible(Type, Args...)>
+{
+};
+
+template<class Type, class... Args>
+inline constexpr bool is_nothrow_constructible_v = is_nothrow_constructible<Type, Args...>::value;
+
+} // namespace pw
+
+#endif /* INCLUDED_PW_IMPL_IS_MOVE_CONSTRUCTIBLE_H */

--- a/pw/impl/is_union.h
+++ b/pw/impl/is_union.h
@@ -3,10 +3,12 @@
 
 namespace pw {
 /// is_union
-template<typename Type>
-struct is_union: public integral_constant<bool, __is_union(Type)>
+template<class Type>
+struct is_union : public integral_constant<bool, __is_union(Type)>
 {
 };
 
+template<class Type>
+inline constexpr bool is_union_v = using is_union<Type>::value;
 }
 #endif /* INCLUDED_PW_IMPLE_IS_UNION_H */

--- a/pw/impl/move_alg.h
+++ b/pw/impl/move_alg.h
@@ -14,7 +14,7 @@ move(InputIterator begin, InputIterator end, OutputIterator dest)
     {
         *dest++ = pw::move(*begin++);
     }
-    return begin;
+    return dest;
 }
 } // namespace pw
 

--- a/pw/internal/storage.h
+++ b/pw/internal/storage.h
@@ -105,7 +105,7 @@ public:
         pw::swap(op1.m_end, op2.m_end);
         pw::swap(op1.m_allocated, op2.m_allocated);
     }
-    // void moveto(iterator begin, iterator end, iterator dest);
+    void moveto(iterator begin, iterator end, iterator dest);
     // void cons(iterator begin, iterator end, Type const& value);
 
 private:
@@ -271,24 +271,24 @@ Storage<Type, Allocator>::get_allocator() const
     return m_alloc;
 }
 
-// template<class Type, class Allocator>
-// void
-// Storage<Type, Allocator>::moveto(iterator begin, iterator end, iterator dest)
-// {
-//     while (end != begin)
-//     {
-//         --dest;
-//         --end;
-//         if (dest >= m_end)
-//         {
-//             allocator_traits<Allocator>::construct(m_alloc, dest, pw::move(*end));
-//         }
-//         else
-//         {
-//             *dest = pw::move(*end);
-//         }
-//     }
-// }
+template<class Type, class Allocator>
+void
+Storage<Type, Allocator>::moveto(iterator begin, iterator end, iterator dest)
+{
+    while (end != begin)
+    {
+        --dest;
+        --end;
+        if (dest >= m_end)
+        {
+            allocator_traits<Allocator>::construct(m_alloc, dest, pw::move(*end));
+        }
+        else
+        {
+            *dest = pw::move(*end);
+        }
+    }
+}
 
 // template<class Type, class Allocator>
 // void

--- a/pw/internal/storage.h
+++ b/pw/internal/storage.h
@@ -69,11 +69,7 @@ private:
 public:
     Storage(allocator_type const& alloc = allocator_type());
     explicit Storage(size_type count, allocator_type const& alloc = allocator_type());
-    Storage(Storage const& copy, allocator_type const& alloc = allocator_type());
-    Storage(Storage&& copy);
-    Storage(Storage&& copy, size_type count, allocator_type const& alloc);
     ~Storage();
-    Storage& operator=(Storage op2);
     /**
      * Allocate enough space for count records.  Then up to
      * count records are moved into new Storage.
@@ -132,54 +128,10 @@ Storage<Type, Allocator>::Storage(size_type count, allocator_type const& alloc)
 }
 
 template<class Type, class Allocator>
-Storage<Type, Allocator>::Storage(Storage const& copy, allocator_type const& alloc)
-    : m_alloc(alloc)
-    , m_begin(allocator_traits<Allocator>::allocate(m_alloc, copy.size()))
-    , m_end(m_begin + copy.size())
-    , m_allocated(copy.size())
-{
-    pw::uninitialized_copy(copy.m_begin, copy.m_end, m_begin);
-}
-
-template<class Type, class Allocator>
-Storage<Type, Allocator>::Storage(Storage&& copy)
-    : m_alloc { copy.m_alloc }
-    , m_begin { pw::exchange(copy.m_begin, nullptr) }
-    , m_end { pw::exchange(copy.m_end, nullptr) }
-    , m_allocated { pw::exchange(copy.m_allocated, 0) }
-{
-}
-
-/**
- * Allocate enough space for count records and
- * move/copy them
- */
-template<class Type, class Allocator>
-Storage<Type, Allocator>::Storage(Storage&& copy, size_type count, allocator_type const& alloc)
-    : m_alloc(alloc)
-    , m_begin(allocator_traits<Allocator>::allocate(m_alloc, count))
-    , m_end(0)
-    , m_allocated(count)
-{
-    size_type final = min(count, copy.size());
-
-    pw::uninitialized_move(copy.begin(), copy.begin() + final, m_begin);
-    m_end = m_begin + final;
-}
-
-template<class Type, class Allocator>
 Storage<Type, Allocator>::~Storage()
 {
     pw::destroy(begin(), end());
     allocator_traits<Allocator>::deallocate(m_alloc, m_begin, m_allocated);
-}
-
-template<class Type, class Allocator>
-Storage<Type, Allocator>&
-Storage<Type, Allocator>::operator=(Storage op2)
-{
-    swap(op2);
-    return *this;
 }
 
 template<class Type, class Allocator>

--- a/pw/internal/storage.h
+++ b/pw/internal/storage.h
@@ -70,13 +70,15 @@ public:
     Storage(allocator_type const& alloc = allocator_type());
     explicit Storage(size_type count, allocator_type const& alloc = allocator_type());
     ~Storage();
+    Storage& operator=(Storage& op2) = delete;
+
     /**
      * Allocate enough space for count records.  Then up to
      * count records are moved into new Storage.
      */
-    void                  move(size_type offset, size_type count, Type const& value);
-    Storage               resize(size_type offset, size_type count, Type const& value);
-    Storage               split(size_type offset, size_type count);
+    // void                  move(size_type offset, size_type count, Type const& value);
+    // Storage               resize(size_type offset, size_type count, Type const& value);
+    // Storage               split(size_type offset, size_type count);
     iterator              begin();
     iterator              end();
     const_iterator        begin() const;
@@ -103,8 +105,8 @@ public:
         pw::swap(op1.m_end, op2.m_end);
         pw::swap(op1.m_allocated, op2.m_allocated);
     }
-    void moveto(iterator begin, iterator end, iterator dest);
-    void cons(iterator begin, iterator end, Type const& value);
+    // void moveto(iterator begin, iterator end, iterator dest);
+    // void cons(iterator begin, iterator end, Type const& value);
 
 private:
 };
@@ -134,41 +136,41 @@ Storage<Type, Allocator>::~Storage()
     allocator_traits<Allocator>::deallocate(m_alloc, m_begin, m_allocated);
 }
 
-template<class Type, class Allocator>
-Storage<Type, Allocator>
-Storage<Type, Allocator>::resize(size_type offset, size_type count, Type const& value)
-{
-    Storage s = split(offset, count);
+// template<class Type, class Allocator>
+// Storage<Type, Allocator>
+// Storage<Type, Allocator>::resize(size_type offset, size_type count, Type const& value)
+// {
+//     Storage s = split(offset, count);
 
-    pw::uninitialized_fill(s.begin() + offset, s.begin() + offset + count, value);
-    s.set_size(size() + count);
-    return s;
-}
+//     pw::uninitialized_fill(s.begin() + offset, s.begin() + offset + count, value);
+//     s.set_size(size() + count);
+//     return s;
+// }
 
-template<class Type, class Allocator>
-Storage<Type, Allocator>
-Storage<Type, Allocator>::split(size_type offset, size_type count)
-{
-    Storage s(size() + count, m_alloc);
+// template<class Type, class Allocator>
+// Storage<Type, Allocator>
+// Storage<Type, Allocator>::split(size_type offset, size_type count)
+// {
+//     Storage s(size() + count, m_alloc);
 
-    pw::uninitialized_move(begin(), pw::next(begin(), offset), s.begin());
-    pw::uninitialized_move(pw::next(begin(), offset), end(), pw::next(s.begin(), offset + count));
-    return s;
-}
+//     pw::uninitialized_move(begin(), pw::next(begin(), offset), s.begin());
+//     pw::uninitialized_move(pw::next(begin(), offset), end(), pw::next(s.begin(), offset + count));
+//     return s;
+// }
 
-/**
- * Allocate enough space for count records.  Then up to
- * count records are moved into new Storage and others
- * are destroyed.
- */
-template<class Type, class Allocator>
-void
-Storage<Type, Allocator>::move(size_type offset, size_type count, Type const& value)
-{
-    moveto(m_begin + offset, m_end, m_end + offset);
-    cons(m_begin + offset, m_begin + offset + count, value);
-    set_size(size() + count);
-}
+// /**
+//  * Allocate enough space for count records.  Then up to
+//  * count records are moved into new Storage and others
+//  * are destroyed.
+//  */
+// template<class Type, class Allocator>
+// void
+// Storage<Type, Allocator>::move(size_type offset, size_type count, Type const& value)
+// {
+//     moveto(m_begin + offset, m_end, m_end + offset);
+//     cons(m_begin + offset, m_begin + offset + count, value);
+//     set_size(size() + count);
+// }
 
 template<class Type, class Allocator>
 typename Storage<Type, Allocator>::iterator
@@ -269,42 +271,42 @@ Storage<Type, Allocator>::get_allocator() const
     return m_alloc;
 }
 
-template<class Type, class Allocator>
-void
-Storage<Type, Allocator>::moveto(iterator begin, iterator end, iterator dest)
-{
-    while (end != begin)
-    {
-        --dest;
-        --end;
-        if (dest >= m_end)
-        {
-            allocator_traits<Allocator>::construct(m_alloc, dest, pw::move(*end));
-        }
-        else
-        {
-            *dest = pw::move(*end);
-        }
-    }
-}
+// template<class Type, class Allocator>
+// void
+// Storage<Type, Allocator>::moveto(iterator begin, iterator end, iterator dest)
+// {
+//     while (end != begin)
+//     {
+//         --dest;
+//         --end;
+//         if (dest >= m_end)
+//         {
+//             allocator_traits<Allocator>::construct(m_alloc, dest, pw::move(*end));
+//         }
+//         else
+//         {
+//             *dest = pw::move(*end);
+//         }
+//     }
+// }
 
-template<class Type, class Allocator>
-void
-Storage<Type, Allocator>::cons(iterator begin, iterator end, Type const& value)
-{
-    while (begin != end)
-    {
-        if (begin < end)
-        {
-            *begin = value;
-        }
-        else
-        {
-            allocator_traits<Allocator>::construct(m_alloc, begin, value);
-        }
-        ++begin;
-    }
-}
+// template<class Type, class Allocator>
+// void
+// Storage<Type, Allocator>::cons(iterator begin, iterator end, Type const& value)
+// {
+//     while (begin != end)
+//     {
+//         if (begin < end)
+//         {
+//             *begin = value;
+//         }
+//         else
+//         {
+//             allocator_traits<Allocator>::construct(m_alloc, begin, value);
+//         }
+//         ++begin;
+//     }
+// }
 
 }} // namespace pw::internal
 #endif /*  INCLUDED_PW_INTERNAL_STORAGE_H */

--- a/pw/internal/storage.h
+++ b/pw/internal/storage.h
@@ -73,13 +73,6 @@ public:
     ~Storage();
     Storage& operator=(Storage& op2) = delete;
 
-    /**
-     * Allocate enough space for count records.  Then up to
-     * count records are moved into new Storage.
-     */
-    // void                  move(size_type offset, size_type count, Type const& value);
-    // Storage               resize(size_type offset, size_type count, Type const& value);
-    // Storage               split(size_type offset, size_type count);
     iterator              begin();
     iterator              end();
     const_iterator        begin() const;
@@ -109,7 +102,6 @@ public:
     void moveto(iterator begin, iterator end, iterator dest);
     template<class Iterator>
     void copyto(Iterator first, Iterator last, iterator dest);
-    // void cons(iterator begin, iterator end, Type const& value);
 
 private:
 };
@@ -138,42 +130,6 @@ Storage<Type, Allocator>::~Storage()
     pw::destroy(begin(), end());
     allocator_traits<Allocator>::deallocate(m_alloc, m_begin, m_allocated);
 }
-
-// template<class Type, class Allocator>
-// Storage<Type, Allocator>
-// Storage<Type, Allocator>::resize(size_type offset, size_type count, Type const& value)
-// {
-//     Storage s = split(offset, count);
-
-//     pw::uninitialized_fill(s.begin() + offset, s.begin() + offset + count, value);
-//     s.set_size(size() + count);
-//     return s;
-// }
-
-// template<class Type, class Allocator>
-// Storage<Type, Allocator>
-// Storage<Type, Allocator>::split(size_type offset, size_type count)
-// {
-//     Storage s(size() + count, m_alloc);
-
-//     pw::uninitialized_move(begin(), pw::next(begin(), offset), s.begin());
-//     pw::uninitialized_move(pw::next(begin(), offset), end(), pw::next(s.begin(), offset + count));
-//     return s;
-// }
-
-// /**
-//  * Allocate enough space for count records.  Then up to
-//  * count records are moved into new Storage and others
-//  * are destroyed.
-//  */
-// template<class Type, class Allocator>
-// void
-// Storage<Type, Allocator>::move(size_type offset, size_type count, Type const& value)
-// {
-//     moveto(m_begin + offset, m_end, m_end + offset);
-//     cons(m_begin + offset, m_begin + offset + count, value);
-//     set_size(size() + count);
-// }
 
 template<class Type, class Allocator>
 typename Storage<Type, Allocator>::iterator

--- a/pw/internal/storage.h
+++ b/pw/internal/storage.h
@@ -5,6 +5,7 @@
 #include <pw/impl/allocator_traits.h>
 #include <pw/impl/copy.h>
 #include <pw/impl/destroy.h>
+#include <pw/impl/distance.h>
 #include <pw/impl/exchange.h>
 #include <pw/impl/max.h>
 #include <pw/impl/min.h>
@@ -106,6 +107,8 @@ public:
         pw::swap(op1.m_allocated, op2.m_allocated);
     }
     void moveto(iterator begin, iterator end, iterator dest);
+    template<class Iterator>
+    void copyto(Iterator first, Iterator last, iterator dest);
     // void cons(iterator begin, iterator end, Type const& value);
 
 private:
@@ -290,23 +293,16 @@ Storage<Type, Allocator>::moveto(iterator begin, iterator end, iterator dest)
     }
 }
 
-// template<class Type, class Allocator>
-// void
-// Storage<Type, Allocator>::cons(iterator begin, iterator end, Type const& value)
-// {
-//     while (begin != end)
-//     {
-//         if (begin < end)
-//         {
-//             *begin = value;
-//         }
-//         else
-//         {
-//             allocator_traits<Allocator>::construct(m_alloc, begin, value);
-//         }
-//         ++begin;
-//     }
-// }
+template<class Type, class Allocator>
+template<class Iterator>
+void
+Storage<Type, Allocator>::copyto(Iterator first, Iterator last, iterator dest)
+{
+    auto overlap            = pw::distance(dest, end());
+    auto uninitialized_dest = pw::copy(first, next(first, overlap), dest);
+
+    pw::uninitialized_copy(next(first, overlap), last, uninitialized_dest);
+}
 
 }} // namespace pw::internal
 #endif /*  INCLUDED_PW_INTERNAL_STORAGE_H */

--- a/pw/vector
+++ b/pw/vector
@@ -711,7 +711,7 @@ vector<Type, Allocator>::insert(const_iterator position, size_type count, const_
     {
         //TODO: uninitialized_move(x, y, pw::back_inserter(m_data));
         //move_backward(
-        m_data.move(offset, count, value);
+        //m_data.move(offset, count, value);
     }
     return pw::next(m_data.begin(), offset);
 }
@@ -735,9 +735,10 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
     }
     else
     {
-        m_data.moveto(pw::next(m_data.begin(), offset),
-                      pw::next(m_data.begin(), offset + count),
-                      pw::next(m_data.begin(), offset));
+        // TODO: imploement move
+        // m_data.moveto(pw::next(m_data.begin(), offset),
+        //               pw::next(m_data.begin(), offset + count),
+        //               pw::next(m_data.begin(), offset));
         pw::copy(first, last, pw::next(m_data.begin(), offset));
         m_data.set_size(m_data.size() + count);
     }
@@ -749,15 +750,20 @@ template<class... Args>
 typename vector<Type, Allocator>::reference
 vector<Type, Allocator>::emplace_back(Args&&... args)
 {
-    if (!m_data.hascapacity())
+    if (m_data.hascapacity())
     {
-        //Storage s(pw::move(m_data), m_data.newsize(), m_data.get_allocator());
+        allocator_traits<Allocator>::construct(
+            m_data.get_allocator(), m_data.end(), pw::forward<Args>(args)...);
+        m_data.set_size(m_data.size() + 1);
+    }
+    else
+    {
         Storage s(m_data.newsize(), m_data.get_allocator());
-        // Implement move
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size() + 1);
+        allocator_traits<Allocator>::construct(s.get_allocator(), s.end(), pw::forward<Args>(args)...);
         m_data.swap(s);
     }
-    allocator_traits<Allocator>::construct(m_data.get_allocator(), m_data.end(), pw::forward<Args>(args)...);
-    m_data.set_size(m_data.size() + 1);
     return *pw::prev(m_data.end(), 1);
 }
 

--- a/pw/vector
+++ b/pw/vector
@@ -530,8 +530,8 @@ vector<Type, Allocator>::shrink_to_fit()
     else
     {
         Storage s(size(), get_allocator());
-        // Storage s(pw::move(m_data), size(), get_allocator());
-        // TODO: implement move
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
         m_data.swap(s);
     }
 }
@@ -605,30 +605,38 @@ template<class Type, class Allocator>
 void
 vector<Type, Allocator>::push_back(const_reference value)
 {
-    if (!m_data.hascapacity())
+    if (m_data.hascapacity())
+    {
+        m_data.push_back(value);
+    }
+    else
     {
         Storage s(m_data.newsize(), get_allocator());
 
         pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
         s.set_size(m_data.size());
+        s.push_back(value);
         m_data.swap(s);
     }
-    m_data.push_back(value);
 }
 
 template<class Type, class Allocator>
 void
 vector<Type, Allocator>::push_back(value_type&& value)
 {
-    if (!m_data.hascapacity())
+    if (m_data.hascapacity())
+    {
+        m_data.push_back(pw::move(value));
+    }
+    else
     {
         Storage s(m_data.newsize(), get_allocator());
 
         pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
         s.set_size(m_data.size());
+        s.push_back(pw::move(value));
         m_data.swap(s);
     }
-    m_data.push_back(pw::move(value));
 }
 
 template<class Type, class Allocator>

--- a/pw/vector
+++ b/pw/vector
@@ -1,6 +1,7 @@
 #ifndef PW_VECTOR_H // -*- c++ -*-
 #define PW_VECTOR_H
 
+#include <pw/impl/advance.h>
 #include <pw/impl/allocator.h>
 #include <pw/impl/allocator_traits.h>
 #include <pw/impl/back_inserter.h>
@@ -572,7 +573,7 @@ struct StorageMove
     {
         try
         {
-            uninitialized_move(src.begin(), src.end(), back_inserter(m_dst));
+            uninitialized_move(src.begin(), src.end(), pw::back_inserter(m_dst));
         }
         catch (...)
         {
@@ -607,7 +608,9 @@ vector<Type, Allocator>::push_back(const_reference value)
     if (!m_data.hascapacity())
     {
         Storage s(m_data.newsize(), get_allocator());
-        // TODO: implement move
+
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
         m_data.swap(s);
     }
     m_data.push_back(value);
@@ -620,7 +623,9 @@ vector<Type, Allocator>::push_back(value_type&& value)
     if (!m_data.hascapacity())
     {
         Storage s(m_data.newsize(), get_allocator());
-        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
+
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
         m_data.swap(s);
     }
     m_data.push_back(pw::move(value));
@@ -639,8 +644,8 @@ vector<Type, Allocator>::resize(size_type count)
     {
         Storage s(count, get_allocator());
 
-        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
-        fill_n(back_inserter(s), count - m_data.size(), value_type());
+        //        uninitialized_move(m_data.begin(), m_data.end(), pw::back_inserter(s));
+        pw::fill_n(pw::back_inserter(s), count - m_data.size(), value_type());
         m_data.swap(s);
     }
 }
@@ -658,8 +663,8 @@ vector<Type, Allocator>::resize(size_type count, const_reference value)
     {
         Storage s(count, get_allocator());
 
-        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
-        fill_n(back_inserter(s), count - m_data.size(), value);
+        //        uninitialized_move(m_data.begin(), m_data.end(), pw::back_inserter(s));
+        pw::fill_n(pw::back_inserter(s), count - m_data.size(), value);
         m_data.swap(s);
     }
 }
@@ -711,15 +716,15 @@ vector<Type, Allocator>::insert(const_iterator position, size_type count, const_
     {
         Storage s(m_data.size() + count, get_allocator());
 
-        uninitialized_move(m_data.begin(), position, back_inserter(s));
-        fill_n(back_inserter(s), advance(s.begin(), offset), count, value);
-        uninitialized_move(position, m_data.end(), back_inserter(s));
+        //        uninitialized_move(m_data.begin(), position, pw::back_inserter(s));
+        //        pw::fill_n(pw::back_inserter(s), advance(s.begin(), offset), count, value);
+        //        uninitialized_move(position, m_data.end(), pw::back_inserter(s));
 
         m_data.swap(s);
     }
     else
     {
-        //TODO: uninitialized_move(x, y, back_inserter(m_data));
+        //TODO: uninitialized_move(x, y, pw::back_inserter(m_data));
         //move_backward(
         m_data.move(offset, count, value);
     }

--- a/pw/vector
+++ b/pw/vector
@@ -155,16 +155,16 @@ template<class Type, class Allocator>
 vector<Type, Allocator>::vector(size_type count)
     : m_data(count, allocator_type())
 {
+    pw::uninitialized_default_construct(m_data.begin(), m_data.begin() + count);
     m_data.set_size(count);
-    pw::uninitialized_default_construct(m_data.begin(), m_data.end());
 }
 
 template<class Type, class Allocator>
 vector<Type, Allocator>::vector(size_type count, value_type const& value, allocator_type const& alloc)
     : m_data(count, alloc)
 {
+    pw::uninitialized_fill(m_data.begin(), m_data.begin() + count, value);
     m_data.set_size(count);
-    pw::uninitialized_fill(m_data.begin(), m_data.end(), value);
 }
 
 template<class Type, class Allocator>
@@ -173,14 +173,16 @@ vector<Type, Allocator>::vector(vector const& copy)
           copy.size(),
           pw::allocator_traits<allocator_type>::select_on_container_copy_construction(copy.get_allocator()))
 {
-    // TODO: Need to implement copy
+    pw::uninitialized_copy(copy.m_data.begin(), copy.m_data.end(), m_data.begin());
+    m_data.set_size(copy.m_data.size());
 }
 
 template<class Type, class Allocator>
 vector<Type, Allocator>::vector(vector&& other) noexcept
     : m_data(other.size(), allocator_type())
 {
-    // TODO: implement move
+    pw::uninitialized_move(other.m_data.begin(), other.m_data.end(), m_data.begin());
+    m_data.set_size(other.m_data.size());
 }
 
 template<class Type, class Allocator>
@@ -209,8 +211,10 @@ vector<Type, Allocator>::operator=(const vector& other)
 {
     if (m_data.capacity() < other.size())
     {
-        //m_data = Storage(other.m_data, get_allocator());
-        // TODO: implement assignment
+        Storage s(other.size(), get_allocator());
+        pw::uninitialized_copy(other.begin(), other.end(), s.begin());
+        s.set_size(other.size());
+        m_data.swap(s);
     }
     else
     {
@@ -556,33 +560,6 @@ vector<Type, Allocator>::clear() noexcept
     pw::destroy(m_data.begin(), m_data.end());
     m_data.set_size(0);
 }
-
-template<class Type, class Allocator>
-struct StorageMove
-{
-    using Storage = internal::Storage<Type, Allocator>;
-
-    Storage& m_src;
-    Storage& m_dst;
-    size_t   m_index;
-
-    StorageMove(Storage& src, Storage& dst)
-        : m_src(src)
-        , m_dst(dst)
-        , m_index(0)
-    {
-        try
-        {
-            uninitialized_move(src.begin(), src.end(), pw::back_inserter(m_dst));
-        }
-        catch (...)
-        {
-            throw;
-        }
-    }
-
-    ~StorageMove() { }
-};
 
 /**
  * Appends the given element value to the end of the container.

--- a/pw/vector
+++ b/pw/vector
@@ -731,8 +731,8 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
 
     if (m_data.hascapacity(count))
     {
-        m_data.moveto(pw::next(m_data.begin(), offset), m_data.end(), pw::next(m_data.end(), count));
-        pw::copy(first, last, pw::next(m_data.begin(), offset));
+        m_data.moveto(next(m_data.begin(), offset), m_data.end(), next(m_data.end(), count));
+        m_data.copyto(first, last, next(m_data.begin(), offset));
         m_data.set_size(m_data.size() + count);
     }
     else

--- a/pw/vector
+++ b/pw/vector
@@ -760,8 +760,9 @@ vector<Type, Allocator>::emplace_back(Args&&... args)
     {
         Storage s(m_data.newsize(), m_data.get_allocator());
         pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
-        s.set_size(m_data.size() + 1);
+        s.set_size(m_data.size());
         allocator_traits<Allocator>::construct(s.get_allocator(), s.end(), pw::forward<Args>(args)...);
+        s.set_size(m_data.size() + 1);
         m_data.swap(s);
     }
     return *pw::prev(m_data.end(), 1);

--- a/pw/vector
+++ b/pw/vector
@@ -1,7 +1,6 @@
 #ifndef PW_VECTOR_H // -*- c++ -*-
 #define PW_VECTOR_H
 
-#include <pw/impl/advance.h>
 #include <pw/impl/allocator.h>
 #include <pw/impl/allocator_traits.h>
 #include <pw/impl/back_inserter.h>
@@ -697,21 +696,22 @@ vector<Type, Allocator>::insert(const_iterator position, size_type count, const_
 {
     difference_type offset = pw::distance(const_iterator(m_data.begin()), position);
 
-    if (!m_data.hascapacity(count))
+    if (m_data.hascapacity(count))
     {
-        Storage s(m_data.size() + count, get_allocator());
-
-        //        uninitialized_move(m_data.begin(), position, pw::back_inserter(s));
-        //        pw::fill_n(pw::back_inserter(s), advance(s.begin(), offset), count, value);
-        //        uninitialized_move(position, m_data.end(), pw::back_inserter(s));
-
-        m_data.swap(s);
+        m_data.moveto(pw::next(m_data.begin(), offset), m_data.end(), pw::next(m_data.end(), count));
+        pw::fill_n(pw::next(m_data.begin(), offset), count, value);
+        m_data.set_size(m_data.size() + count);
     }
     else
     {
-        //TODO: uninitialized_move(x, y, pw::back_inserter(m_data));
-        //move_backward(
-        //m_data.move(offset, count, value);
+        Storage s(m_data.size() + count, get_allocator());
+
+        pw::uninitialized_move(m_data.begin(), pw::next(m_data.begin(), offset), s.begin());
+        pw::uninitialized_fill(pw::next(s.begin(), offset), pw::next(s.begin(), offset + count), value);
+        pw::uninitialized_move(
+            pw::next(m_data.begin(), offset), m_data.end(), pw::next(s.begin(), offset + count));
+        s.set_size(m_data.size() + count);
+        m_data.swap(s);
     }
     return pw::next(m_data.begin(), offset);
 }
@@ -727,6 +727,7 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
     if (!m_data.hascapacity(count))
     {
         Storage s(m_data.capacity() + count, get_allocator());
+        throw std::runtime_error("insert(position,first,last) implementation not finished");
         // Storage s(m_data.split(offset, count));
         // TODO: implement split
         pw::uninitialized_move(first, last, pw::next(s.begin(), offset));
@@ -735,6 +736,7 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
     }
     else
     {
+        throw std::runtime_error("insert(position,first,last) implementation not finished");
         // TODO: imploement move
         // m_data.moveto(pw::next(m_data.begin(), offset),
         //               pw::next(m_data.begin(), offset + count),

--- a/pw/vector
+++ b/pw/vector
@@ -8,6 +8,7 @@
 #include <pw/impl/distance.h>
 #include <pw/impl/equal.h>
 #include <pw/impl/fill.h>
+#include <pw/impl/fill_n.h>
 #include <pw/impl/for_each.h>
 #include <pw/impl/forward.h>
 #include <pw/impl/iterator_traits.h>
@@ -556,6 +557,50 @@ vector<Type, Allocator>::clear() noexcept
 }
 
 template<class Type, class Allocator>
+struct StorageMove
+{
+    using Storage = internal::Storage<Type, Allocator>;
+
+    Storage& m_src;
+    Storage& m_dst;
+    size_t   m_index;
+
+    StorageMove(Storage& src, Storage& dst)
+        : m_src(src)
+        , m_dst(dst)
+        , m_index(0)
+    {
+        try
+        {
+            uninitialized_move(src.begin(), src.end(), back_inserter(m_dst));
+        }
+        catch (...)
+        {
+            throw;
+        }
+    }
+
+    ~StorageMove() { }
+};
+
+/**
+ * Appends the given element value to the end of the container.
+ * - The new element is initialized as a copy of value.
+ * - value is moved into the new element.
+ *
+ * If the new size() is greater than capacity() then all iterators and
+ * references (including the past-the-end iterator) are invalidated. Otherwise
+ * only the past-the-end iterator is invalidated.
+ * 
+ * If an exception is thrown (which can be due to Allocator::allocate() or
+ * element copy/move constructor/assignment), this function has no effect
+ * (strong exception guarantee).
+ *
+ * If T's move constructor is not noexcept and T is not CopyInsertable into
+ * *this, vector will use the throwing move constructor. If it throws, the
+ * guarantee is waived and the effects are unspecified.
+ */
+template<class Type, class Allocator>
 void
 vector<Type, Allocator>::push_back(const_reference value)
 {
@@ -574,8 +619,8 @@ vector<Type, Allocator>::push_back(value_type&& value)
 {
     if (!m_data.hascapacity())
     {
-        // TODO: implement move
         Storage s(m_data.newsize(), get_allocator());
+        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
         m_data.swap(s);
     }
     m_data.push_back(pw::move(value));
@@ -593,9 +638,9 @@ vector<Type, Allocator>::resize(size_type count)
     else if (m_data.size() < count)
     {
         Storage s(count, get_allocator());
-        // TODO: implement move
-        pw::uninitialized_default_construct(s.end(), pw::next(s.end(), count - s.size()));
-        s.set_size(count);
+
+        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
+        fill_n(back_inserter(s), count - m_data.size(), value_type());
         m_data.swap(s);
     }
 }
@@ -612,9 +657,9 @@ vector<Type, Allocator>::resize(size_type count, const_reference value)
     else if (m_data.size() < count)
     {
         Storage s(count, get_allocator());
-        // TODO: implement move
-        pw::uninitialized_fill(s.end(), pw::next(s.end(), count - s.size()), value);
-        s.set_size(count);
+
+        uninitialized_move(m_data.begin(), m_data.end(), back_inserter(s));
+        fill_n(back_inserter(s), count - m_data.size(), value);
         m_data.swap(s);
     }
 }
@@ -664,10 +709,18 @@ vector<Type, Allocator>::insert(const_iterator position, size_type count, const_
 
     if (!m_data.hascapacity(count))
     {
-        m_data = m_data.resize(offset, count, value);
+        Storage s(m_data.size() + count, get_allocator());
+
+        uninitialized_move(m_data.begin(), position, back_inserter(s));
+        fill_n(back_inserter(s), advance(s.begin(), offset), count, value);
+        uninitialized_move(position, m_data.end(), back_inserter(s));
+
+        m_data.swap(s);
     }
     else
     {
+        //TODO: uninitialized_move(x, y, back_inserter(m_data));
+        //move_backward(
         m_data.move(offset, count, value);
     }
     return pw::next(m_data.begin(), offset);

--- a/pw/vector
+++ b/pw/vector
@@ -168,21 +168,24 @@ vector<Type, Allocator>::vector(size_type count, value_type const& value, alloca
 template<class Type, class Allocator>
 vector<Type, Allocator>::vector(vector const& copy)
     : m_data(
-          copy.m_data,
+          copy.size(),
           pw::allocator_traits<allocator_type>::select_on_container_copy_construction(copy.get_allocator()))
 {
+    // TODO: Need to implement copy
 }
 
 template<class Type, class Allocator>
 vector<Type, Allocator>::vector(vector&& other) noexcept
-    : m_data(pw::move(other.m_data), allocator_type())
+    : m_data(other.size(), allocator_type())
 {
+    // TODO: implement move
 }
 
 template<class Type, class Allocator>
 vector<Type, Allocator>::vector(vector&& other, const Allocator& alloc)
-    : m_data(pw::move(other.m_data), alloc)
+    : m_data(other.size(), alloc)
 {
+    // TODO: implement move
 }
 
 template<class Type, class Allocator>
@@ -204,7 +207,8 @@ vector<Type, Allocator>::operator=(const vector& other)
 {
     if (m_data.capacity() < other.size())
     {
-        m_data = Storage(other.m_data, get_allocator());
+        //m_data = Storage(other.m_data, get_allocator());
+        // TODO: implement assignment
     }
     else
     {
@@ -226,7 +230,9 @@ vector<Type, Allocator>::operator=(vector&& other) noexcept
     }
     else if (m_data.capacity() < other.size())
     {
-        Storage s(pw::move(other.m_data), other.size(), get_allocator());
+        //Storage s(pw::move(other.m_data), other.size(), get_allocator());
+        Storage s(other.size(), get_allocator());
+        // TODO: implement move
         m_data.swap(s);
     }
     else
@@ -521,7 +527,9 @@ vector<Type, Allocator>::shrink_to_fit()
     }
     else
     {
-        Storage s(pw::move(m_data), size(), get_allocator());
+        Storage s(size(), get_allocator());
+        // Storage s(pw::move(m_data), size(), get_allocator());
+        // TODO: implement move
         m_data.swap(s);
     }
 }
@@ -532,7 +540,9 @@ vector<Type, Allocator>::reserve(size_type count)
 {
     if (count > capacity())
     {
-        Storage s(pw::move(m_data), count, get_allocator());
+        //Storage s(pw::move(m_data), count, get_allocator());
+        Storage s(count, get_allocator());
+        // TODO: implement count
         m_data.swap(s);
     }
 }
@@ -549,9 +559,10 @@ template<class Type, class Allocator>
 void
 vector<Type, Allocator>::push_back(const_reference value)
 {
-    if (m_data.capacity() == m_data.size())
+    if (!m_data.hascapacity())
     {
-        Storage s(pw::move(m_data), m_data.newsize(), get_allocator());
+        Storage s(m_data.newsize(), get_allocator());
+        // TODO: implement move
         m_data.swap(s);
     }
     m_data.push_back(value);
@@ -563,7 +574,8 @@ vector<Type, Allocator>::push_back(value_type&& value)
 {
     if (!m_data.hascapacity())
     {
-        Storage s(pw::move(m_data), m_data.newsize(), get_allocator());
+        // TODO: implement move
+        Storage s(m_data.newsize(), get_allocator());
         m_data.swap(s);
     }
     m_data.push_back(pw::move(value));
@@ -580,7 +592,8 @@ vector<Type, Allocator>::resize(size_type count)
     }
     else if (m_data.size() < count)
     {
-        Storage s(pw::move(m_data), count, get_allocator());
+        Storage s(count, get_allocator());
+        // TODO: implement move
         pw::uninitialized_default_construct(s.end(), pw::next(s.end(), count - s.size()));
         s.set_size(count);
         m_data.swap(s);
@@ -598,7 +611,8 @@ vector<Type, Allocator>::resize(size_type count, const_reference value)
     }
     else if (m_data.size() < count)
     {
-        Storage s(pw::move(m_data), count, get_allocator());
+        Storage s(count, get_allocator());
+        // TODO: implement move
         pw::uninitialized_fill(s.end(), pw::next(s.end(), count - s.size()), value);
         s.set_size(count);
         m_data.swap(s);
@@ -669,8 +683,9 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
 
     if (!m_data.hascapacity(count))
     {
-        Storage s(m_data.split(offset, count));
-
+        Storage s(m_data.capacity() + count, get_allocator());
+        // Storage s(m_data.split(offset, count));
+        // TODO: implement split
         pw::uninitialized_move(first, last, pw::next(s.begin(), offset));
         s.set_size(m_data.size() + count);
         m_data.swap(s);
@@ -693,7 +708,9 @@ vector<Type, Allocator>::emplace_back(Args&&... args)
 {
     if (!m_data.hascapacity())
     {
-        Storage s(pw::move(m_data), m_data.newsize(), m_data.get_allocator());
+        //Storage s(pw::move(m_data), m_data.newsize(), m_data.get_allocator());
+        Storage s(m_data.newsize(), m_data.get_allocator());
+        // Implement move
         m_data.swap(s);
     }
     allocator_traits<Allocator>::construct(m_data.get_allocator(), m_data.end(), pw::forward<Args>(args)...);

--- a/pw/vector
+++ b/pw/vector
@@ -630,8 +630,10 @@ vector<Type, Allocator>::resize(size_type count)
     {
         Storage s(count, get_allocator());
 
-        //        uninitialized_move(m_data.begin(), m_data.end(), pw::back_inserter(s));
-        pw::fill_n(pw::back_inserter(s), count - m_data.size(), value_type());
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
+        pw::uninitialized_default_construct(s.end(), s.end() + count - m_data.size());
+        s.set_size(count);
         m_data.swap(s);
     }
 }
@@ -649,7 +651,8 @@ vector<Type, Allocator>::resize(size_type count, const_reference value)
     {
         Storage s(count, get_allocator());
 
-        //        uninitialized_move(m_data.begin(), m_data.end(), pw::back_inserter(s));
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
         pw::fill_n(pw::back_inserter(s), count - m_data.size(), value);
         m_data.swap(s);
     }

--- a/pw/vector
+++ b/pw/vector
@@ -189,6 +189,7 @@ vector<Type, Allocator>::vector(vector&& other, const Allocator& alloc)
     : m_data(other.size(), alloc)
 {
     // TODO: implement move
+    throw std::runtime_error("vector::vector(vector&&, alloc) not implemented");
 }
 
 template<class Type, class Allocator>
@@ -545,9 +546,10 @@ vector<Type, Allocator>::reserve(size_type count)
 {
     if (count > capacity())
     {
-        //Storage s(pw::move(m_data), count, get_allocator());
         Storage s(count, get_allocator());
-        // TODO: implement count
+
+        pw::uninitialized_move(m_data.begin(), m_data.end(), s.begin());
+        s.set_size(m_data.size());
         m_data.swap(s);
     }
 }
@@ -724,25 +726,23 @@ vector<Type, Allocator>::insert(const_iterator position, Iterator first, Iterato
     difference_type offset = pw::distance(const_iterator(m_data.begin()), position);
     difference_type count  = pw::distance(first, last);
 
-    if (!m_data.hascapacity(count))
+    if (m_data.hascapacity(count))
     {
-        Storage s(m_data.capacity() + count, get_allocator());
-        throw std::runtime_error("insert(position,first,last) implementation not finished");
-        // Storage s(m_data.split(offset, count));
-        // TODO: implement split
-        pw::uninitialized_move(first, last, pw::next(s.begin(), offset));
-        s.set_size(m_data.size() + count);
-        m_data.swap(s);
+        m_data.moveto(pw::next(m_data.begin(), offset), m_data.end(), pw::next(m_data.end(), count));
+        pw::copy(first, last, pw::next(m_data.begin(), offset));
+        m_data.set_size(m_data.size() + count);
     }
     else
     {
-        throw std::runtime_error("insert(position,first,last) implementation not finished");
-        // TODO: imploement move
-        // m_data.moveto(pw::next(m_data.begin(), offset),
-        //               pw::next(m_data.begin(), offset + count),
-        //               pw::next(m_data.begin(), offset));
-        pw::copy(first, last, pw::next(m_data.begin(), offset));
-        m_data.set_size(m_data.size() + count);
+        Storage s(m_data.capacity() + count, get_allocator());
+
+        pw::uninitialized_move(m_data.begin(), pw::next(m_data.begin(), offset), s.begin());
+        pw::uninitialized_copy(first, last, pw::next(s.begin(), offset));
+        pw::uninitialized_move(
+            pw::next(m_data.begin(), offset), m_data.end(), pw::next(s.begin(), offset + count));
+
+        s.set_size(m_data.size() + count);
+        m_data.swap(s);
     }
     return pw::next(m_data.begin(), offset);
 }

--- a/tests/test/CMakeLists.txt
+++ b/tests/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources ( pwtest PUBLIC
                 test_random_access_iterator.h
                 test_same.h
                 test_testtype.h
+                test_values.h
                )
 target_link_libraries( pwtest pw )
 

--- a/tests/test/test_optracker.cpp
+++ b/tests/test/test_optracker.cpp
@@ -1,6 +1,7 @@
 #include <test_optracker.h>
 #include <test_permute.h>
 
+#include <iostream>
 
 namespace pw { namespace test {
 
@@ -29,7 +30,7 @@ OpTracker::OpTracker(OpTracker&& copy) noexcept
     : m_value(copy.m_value)
     , m_opCounter(copy.m_opCounter)
 {
-    copy.m_value = -2;
+    //copy.m_value *= -2;
     m_opCounter.addMoveConstructor();
 }
 
@@ -99,6 +100,13 @@ permute(OpTracker& value, int depth)
         return true;
     }
     return false;
+}
+
+std::ostream&
+operator<<(std::ostream& out, OpTracker const& op2)
+{
+    out << op2.value();
+    return out;
 }
 
 }} // namespace pw::test

--- a/tests/test/test_optracker.h
+++ b/tests/test/test_optracker.h
@@ -4,6 +4,8 @@
 #include <pw/impl/move.h>
 #include <test_opcounter.h>
 
+#include <iosfwd>
+
 namespace pw { namespace test {
 
 struct OpTracker
@@ -17,6 +19,7 @@ protected:
     ~OpTracker();
 
 public:
+    using value_type = int;
     int        value() const;
     OpTracker& setValue(int value);
 
@@ -33,7 +36,7 @@ private:
 };
 
 bool permute(OpTracker& value, int depth);
-
+std::ostream& operator<<(std::ostream& out, OpTracker const& op2);
 }} // namespace pw::test
 
 #endif /*  INCLUDED_TEST_OPTRACKER_H */

--- a/tests/test/test_testtype.h
+++ b/tests/test/test_testtype.h
@@ -9,31 +9,6 @@
 
 namespace pw { namespace test {
 using TestTypeList = std::tuple<pw::vector<int>, pw::vector<std::string>, std::vector<int>>;
-
-template<class Container>
-struct Values
-{
-    using value_type = typename Container::value_type;
-    value_type   first_value;
-    value_type   last_value;
-    size_t const count;
-    Container    values;
-
-    Values(size_t total)
-        : count(total)
-    {
-        value_type value;
-
-        for (size_t i = 0; i < count; ++i)
-        {
-            pw::test::permute(value, count);
-            if (i == 0)
-                first_value = value;
-            values.push_back(value);
-            last_value = value;
-        }
-    }
-};
 }} // namespace pw::test
 
 #endif /*  INCLUDED_PW_TEST_TESTTYPE_H */

--- a/tests/test/test_values.h
+++ b/tests/test/test_values.h
@@ -38,5 +38,18 @@ struct Values
     }
 };
 
+template<class Container>
+std::ostream&
+operator<<(std::ostream& out, Values<Container> const& values)
+{
+    out << "#### size = " << values.values.size() << " ###\n";
+    auto iter = values.values.begin();
+    for (size_t i = 0; i < values.count; ++i)
+    {
+        out << i << " = " << *iter++ << '\n';
+    }
+    return out;
+}
+
 }} // namespace pw::test
 #endif /* _INCLUDED_TEST_VALUES_H */

--- a/tests/test/test_values.h
+++ b/tests/test/test_values.h
@@ -1,0 +1,40 @@
+#ifndef _INCLUDED_TEST_VALUES_H
+#define _INCLUDED_TEST_VALUES_H
+
+namespace pw { namespace test {
+
+/**
+ * This provides a simple way to populate a container
+ * with a fixed number of values.  It saves
+ * how mnany values in `count` and the
+ * `first_value` and `last_value`. 
+ *
+ * It uses permute() to generate unique values.
+ */
+template<class Container>
+struct Values
+{
+    using value_type = typename Container::value_type;
+    value_type   first_value;
+    value_type   last_value;
+    size_t const count;
+    Container    values;
+
+    Values(size_t total)
+        : count(total)
+    {
+        value_type value;
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            pw::test::permute(value, count);
+            if (i == 0)
+                first_value = value;
+            values.push_back(value);
+            last_value = value;
+        }
+    }
+};
+
+}} // namespace pw::test
+#endif /* _INCLUDED_TEST_VALUES_H */

--- a/tests/test/test_values.h
+++ b/tests/test/test_values.h
@@ -20,8 +20,10 @@ struct Values
     size_t const count;
     Container    values;
 
-    Values(size_t total)
+    template<class... Args>
+    Values(size_t total, Args&&... args)
         : count(total)
+        , values(pw::forward<Args>(args)...)
     {
         value_type value;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable( unittest
                 unittest.m.cpp
 
                 allocator_traits.t.cpp
+                copy.t.cpp
                 cstddef.t.cpp
                 distance.t.cpp
                 exchange.t.cpp

--- a/tests/unit/copy.t.cpp
+++ b/tests/unit/copy.t.cpp
@@ -1,0 +1,27 @@
+#include <pw/impl/copy.h>
+
+#include <test_copyconstructible.h>
+#include <test_defaultcopyconstructible.h>
+#include <test_moveconstructible.h>
+#include <test_opcounter.h>
+
+#include <catch2/catch.hpp>
+
+SCENARIO("copy", "[copy]")
+{
+    GIVEN("An array of int")
+    {
+        int val[5] = { 0, 1, 2, 3, 4 };
+        int dst[5] = { 5, 4, 3, 2, 1 };
+
+        WHEN("val is copied")
+        {
+            pw::copy(&val[0], &val[5], &dst[0]);
+            THEN("copy succeeded")
+            {
+                REQUIRE(val[0] == dst[0]);
+                REQUIRE(val[4] == dst[4]);
+            }
+        }
+    }
+}

--- a/tests/unit/distance.t.cpp
+++ b/tests/unit/distance.t.cpp
@@ -4,7 +4,7 @@
 
 #include <catch2/catch.hpp>
 
-SCENARIO("validate distance() algorithm", "[distance, algorithm]")
+SCENARIO("validate distance() algorithm", "[distance][algorithm]")
 {
     GIVEN("Two pointers")
     {
@@ -14,18 +14,18 @@ SCENARIO("validate distance() algorithm", "[distance, algorithm]")
         WHEN("get the distance")
         {
             pw::ptrdiff_t d = pw::distance(s, e);
-            THEN("distance is 4")
-            {
-                REQUIRE(4 == d);
-            }
+            THEN("distance is 4") { REQUIRE(4 == d); }
         }
-        WHEN("differnce is negative")
+        WHEN("difference is negative")
         {
             pw::ptrdiff_t d = pw::distance(e, s);
-            THEN("distance is -4")
-            {
-                REQUIRE(-4 == d);
-            }
+            THEN("distance is -4") { REQUIRE(-4 == d); }
+        }
+        WHEN("nullptrs are used")
+        {
+            char*         a = 0;
+            pw::ptrdiff_t d = pw::distance(a, a);
+            THEN("distances is 0") { REQUIRE(0 == d); }
         }
     }
 }

--- a/tests/unit/move.t.cpp
+++ b/tests/unit/move.t.cpp
@@ -20,7 +20,7 @@ SCENARIO("move", "[move]")
             pw::test::OpCounter         counter = m2.getCounter() - init;
             THEN("move construct is called")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(1 == counter.getMoveConstructor());
                 REQUIRE(1 == counter.constructorCount());
             }
@@ -37,7 +37,7 @@ SCENARIO("move", "[move]")
             pw::test::OpCounter         counter = m2.getCounter() - init;
             THEN("copy constructor is called")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(1 == counter.getCopyConstructor());
                 REQUIRE(1 == counter.constructorCount());
             }
@@ -48,7 +48,7 @@ SCENARIO("move", "[move]")
             pw::test::OpCounter         counter = m2.getCounter() - init;
             THEN("move construct is called")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(1 == counter.getMoveConstructor());
                 REQUIRE(1 == counter.constructorCount());
             }

--- a/tests/unit/storage.t.cpp
+++ b/tests/unit/storage.t.cpp
@@ -25,35 +25,29 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
                 REQUIRE((pw::size_t)0 == storage.capacity());
                 REQUIRE(storage.begin() == storage.end());
             }
-            THEN("newsize() is larger")
-            {
-                REQUIRE(storage.newsize() > 0);
-            }
+            THEN("newsize() is larger") { REQUIRE(storage.newsize() > 0); }
         }
     }
     GIVEN("An allocated Storage with 10")
     {
         Storage storage(10, allocator);
-        WHEN("Storage(move, 20)")
-        {
-            Storage s = Storage(pw::move(storage), 20, typename Storage::allocator_type());
-            THEN("size() is 0 but capacity increased")
-            {
-                REQUIRE((pw::size_t)0 == s.size());
-                REQUIRE((pw::size_t)20 == s.capacity());
-            }
-            THEN("storage is empty")
-            {
-                REQUIRE(0 == storage.size());
-                REQUIRE((pw::size_t)10 == storage.capacity());
-            }
-        }
+        // WHEN("Storage(move, 20)")
+        // {
+        //     Storage s = Storage(pw::move(storage), 20, typename Storage::allocator_type());
+        //     THEN("size() is 0 but capacity increased")
+        //     {
+        //         REQUIRE((pw::size_t)0 == s.size());
+        //         REQUIRE((pw::size_t)20 == s.capacity());
+        //     }
+        //     THEN("storage is empty")
+        //     {
+        //         REQUIRE(0 == storage.size());
+        //         REQUIRE((pw::size_t)10 == storage.capacity());
+        //     }
+        // }
         WHEN("newsize() is called")
         {
-            THEN("newsize() is larger")
-            {
-                REQUIRE(storage.newsize() > 10);
-            }
+            THEN("newsize() is larger") { REQUIRE(storage.newsize() > 10); }
         }
     }
     GIVEN("An allocated Storage with 10")
@@ -64,18 +58,9 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
         WHEN("push_back(value)")
         {
             storage.push_back(value);
-            THEN("size() == 1")
-            {
-                REQUIRE(1 == storage.size());
-            }
-            THEN("capacity() == 10")
-            {
-                REQUIRE(10 == storage.capacity());
-            }
-            THEN("*begin() == value")
-            {
-                REQUIRE(value == *storage.begin());
-            }
+            THEN("size() == 1") { REQUIRE(1 == storage.size()); }
+            THEN("capacity() == 10") { REQUIRE(10 == storage.capacity()); }
+            THEN("*begin() == value") { REQUIRE(value == *storage.begin()); }
         }
     }
     GIVEN("An allocated Storage with 10 and one element")
@@ -87,7 +72,8 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
         REQUIRE(*storage.begin() == value);
         WHEN("Storage (move, 20)")
         {
-            Storage s = Storage(pw::move(storage), 20, typename Storage::allocator_type());
+            Storage s = Storage(20, typename Storage::allocator_type());
+            // TODO: implement move
             THEN("size() is 1")
             {
                 REQUIRE(1 == s.size());
@@ -95,10 +81,7 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
                 REQUIRE(1 == storage.size());
                 REQUIRE(10 == storage.capacity());
             }
-            THEN("element is moved")
-            {
-                REQUIRE(*s.begin() == value);
-            }
+            THEN("element is moved") { REQUIRE(*s.begin() == value); }
         }
         WHEN("operator=() is called")
         {
@@ -115,40 +98,22 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
         {
             Storage s(0, allocator);
             s = pw::move(storage);
-            THEN("s now has 1 element")
-            {
-                REQUIRE(s.size() == 1);
-            }
+            THEN("s now has 1 element") { REQUIRE(s.size() == 1); }
         }
         WHEN("swap() is called")
         {
             size_t  capacity = storage.capacity();
             Storage s(0, allocator);
             swap(storage, s);
-            THEN("s now has 1 element")
-            {
-                REQUIRE(s.size() == 1);
-            }
-            THEN("the element was copied")
-            {
-                REQUIRE(*s.begin() == value);
-            }
-            THEN("capacity was copied")
-            {
-                REQUIRE(s.capacity() == capacity);
-            }
-            THEN("storage now has 0 element")
-            {
-                REQUIRE(storage.size() == 0);
-            }
+            THEN("s now has 1 element") { REQUIRE(s.size() == 1); }
+            THEN("the element was copied") { REQUIRE(*s.begin() == value); }
+            THEN("capacity was copied") { REQUIRE(s.capacity() == capacity); }
+            THEN("storage now has 0 element") { REQUIRE(storage.size() == 0); }
         }
         WHEN("move() is called")
         {
             storage.move(0, 3, value);
-            THEN("3 new elements")
-            {
-                REQUIRE(4 == storage.size());
-            }
+            THEN("3 new elements") { REQUIRE(4 == storage.size()); }
         }
     }
 }
@@ -186,16 +151,16 @@ SCENARIO("Storage construct counts", "[storage][count]")
                 REQUIRE(1 == storage.begin()->value());
             }
         }
-        WHEN("Storage with 1 item is moved")
-        {
-            storage.push_back(1);
-            Storage s(pw::move(storage), 10, Storage::allocator_type());
-            THEN("item is moved")
-            {
-                REQUIRE(1 == s.size());
-                REQUIRE(10 == s.capacity());
-            }
-        }
+        // WHEN("Storage with 1 item is moved")
+        // {
+        //     storage.push_back(1);
+        //     Storage s(pw::move(storage), 10, Storage::allocator_type());
+        //     THEN("item is moved")
+        //     {
+        //         REQUIRE(1 == s.size());
+        //         REQUIRE(10 == s.capacity());
+        //     }
+        // }
     }
 
     counter = pw::test::DefaultCopyConstructible::getCounter() - init;
@@ -216,16 +181,16 @@ SCENARIO("Storage move construct counts", "[storage][move]")
         Storage   s(size);
 
         pw::test::OpCounter init = pw::test::DefaultCopyConstructible::getCounter();
-        WHEN("It is moved")
-        {
-            Storage m(pw::move(storage), newsize, storage.get_allocator());
-            counter = pw::test::DefaultCopyConstructible::getCounter() - init;
-            THEN("Only move constructor is called")
-            {
-                INFO("counter = " << counter);
-                REQUIRE(1 == counter.getMoveConstructor());
-                REQUIRE(1 == counter.constructorCount());
-            }
-        }
+        // WHEN("It is moved")
+        // {
+        //     Storage m(pw::move(storage), newsize, storage.get_allocator());
+        //     counter = pw::test::DefaultCopyConstructible::getCounter() - init;
+        //     THEN("Only move constructor is called")
+        //     {
+        //         INFO("counter = " << counter);
+        //         REQUIRE(1 == counter.getMoveConstructor());
+        //         REQUIRE(1 == counter.constructorCount());
+        //     }
+        // }
     }
 }

--- a/tests/unit/storage.t.cpp
+++ b/tests/unit/storage.t.cpp
@@ -70,36 +70,6 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
         pw::test::permute(value, 3);
         storage.push_back(value);
         REQUIRE(*storage.begin() == value);
-        WHEN("Storage (move, 20)")
-        {
-            Storage s = Storage(20, typename Storage::allocator_type());
-            // TODO: implement move
-            THEN("size() is 1")
-            {
-                REQUIRE(1 == s.size());
-                REQUIRE(20 == s.capacity());
-                REQUIRE(1 == storage.size());
-                REQUIRE(10 == storage.capacity());
-            }
-            THEN("element is moved") { REQUIRE(*s.begin() == value); }
-        }
-        WHEN("operator=() is called")
-        {
-            Storage s(10, allocator);
-            s.push_back(value);
-            s = storage;
-            THEN("they are same and destruction works")
-            {
-                REQUIRE(s.size() == storage.size());
-                REQUIRE(s.capacity() == s.size());
-            }
-        }
-        WHEN("operator=(move) is called")
-        {
-            Storage s(0, allocator);
-            s = pw::move(storage);
-            THEN("s now has 1 element") { REQUIRE(s.size() == 1); }
-        }
         WHEN("swap() is called")
         {
             size_t  capacity = storage.capacity();
@@ -109,11 +79,6 @@ TEMPLATE_LIST_TEST_CASE("check impl/storage", "[storage]", TestTypeList)
             THEN("the element was copied") { REQUIRE(*s.begin() == value); }
             THEN("capacity was copied") { REQUIRE(s.capacity() == capacity); }
             THEN("storage now has 0 element") { REQUIRE(storage.size() == 0); }
-        }
-        WHEN("move() is called")
-        {
-            storage.move(0, 3, value);
-            THEN("3 new elements") { REQUIRE(4 == storage.size()); }
         }
     }
 }

--- a/tests/unit/storage.t.cpp
+++ b/tests/unit/storage.t.cpp
@@ -136,15 +136,11 @@ SCENARIO("Storage move construct counts", "[storage][move]")
 {
     using Storage = pw::internal::Storage<pw::test::DefaultCopyConstructible>;
 
-    int const size = 1;
-    Storage   storage(size);
-    storage.push_back(pw::test::DefaultCopyConstructible(3));
+    int const           size = 5;
+    Storage             storage(size);
     pw::test::OpCounter counter;
     GIVEN("A Storage with 1 element")
     {
-        int const newsize = size + 10;
-        Storage   s(size);
-
         pw::test::OpCounter init = pw::test::DefaultCopyConstructible::getCounter();
         // WHEN("It is moved")
         // {

--- a/tests/unit/uninitialized_move.t.cpp
+++ b/tests/unit/uninitialized_move.t.cpp
@@ -1,4 +1,6 @@
 #include <catch2/catch.hpp>
+
+#include <pw/impl/equal.h>
 #include <pw/impl/uninitialized_move.h>
 
 #include <test_copyconstructible.h>
@@ -7,16 +9,16 @@
 
 SCENARIO("check unitialized_move()", "[uninitialized_move]")
 {
-    size_t const                count        = 3;
-    pw::test::CopyConstructible array[count] = {
-        pw::test::CopyConstructible(2),
-        pw::test::CopyConstructible(1),
-        pw::test::CopyConstructible(3),
-    };
-    pw::test::CopyConstructible dest[count] = { 10, 11, 12 };
-    pw::test::OpCounter         init        = pw::test::CopyConstructible::getCounter();
     GIVEN("A src and dst array")
     {
+        size_t const                count        = 3;
+        pw::test::CopyConstructible array[count] = {
+            pw::test::CopyConstructible(2),
+            pw::test::CopyConstructible(1),
+            pw::test::CopyConstructible(3),
+        };
+        pw::test::CopyConstructible dest[count] = { 10, 11, 12 };
+        pw::test::OpCounter         init        = pw::test::CopyConstructible::getCounter();
         WHEN("move")
         {
             pw::uninitialized_move(&array[0], &array[count], &dest[0]);
@@ -34,6 +36,19 @@ SCENARIO("check unitialized_move()", "[uninitialized_move]")
                 REQUIRE(1 == dest[1].value());
                 REQUIRE(3 == dest[2].value());
             }
+        }
+    }
+    GIVEN("Arrays of int")
+    {
+        int const src[] = { 1, 2, 3 };
+        int       dst[] = { 4, 5, 6 };
+
+        WHEN("move the int from src to dst")
+        {
+            pw::uninitialized_move(&src[0], &src[3], &dst[0]);
+            THEN("src is unchanged") { REQUIRE(src[0] == 1); }
+
+            THEN("src and dst same") { REQUIRE(pw::equal(&dst[0], &dst[3], &src[0], &src[3])); }
         }
     }
 }

--- a/tests/unit/vector_access.t.cpp
+++ b/tests/unit/vector_access.t.cpp
@@ -1,4 +1,5 @@
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -23,22 +24,13 @@ TEMPLATE_LIST_TEST_CASE("access methods", "[vector][access]", pw::test::TestType
 
         WHEN("data() is called")
         {
-            THEN("it returns NULL")
-            {
-                REQUIRE(!v.data());
-            }
+            THEN("it returns NULL") { REQUIRE(!v.data()); }
         }
 
         WHEN("at() is called")
         {
-            THEN("at(0) fails")
-            {
-                CHECK_THROWS_AS(v.at(0), std::out_of_range);
-            }
-            THEN("at(10) fails")
-            {
-                CHECK_THROWS_AS(v.at(10), std::out_of_range);
-            }
+            THEN("at(0) fails") { CHECK_THROWS_AS(v.at(0), std::out_of_range); }
+            THEN("at(10) fails") { CHECK_THROWS_AS(v.at(10), std::out_of_range); }
         }
     }
     GIVEN("A const empty vector")
@@ -47,14 +39,8 @@ TEMPLATE_LIST_TEST_CASE("access methods", "[vector][access]", pw::test::TestType
 
         WHEN("at() const is called")
         {
-            THEN("at(0) const fails")
-            {
-                CHECK_THROWS_AS(v.at(0), std::out_of_range);
-            }
-            THEN("at(10) const fails")
-            {
-                CHECK_THROWS_AS(v.at(10), std::out_of_range);
-            }
+            THEN("at(0) const fails") { CHECK_THROWS_AS(v.at(0), std::out_of_range); }
+            THEN("at(10) const fails") { CHECK_THROWS_AS(v.at(10), std::out_of_range); }
         }
     }
     GIVEN("A vector with 5 elements")
@@ -66,57 +52,36 @@ TEMPLATE_LIST_TEST_CASE("access methods", "[vector][access]", pw::test::TestType
         WHEN("at(0) is called")
         {
             value_type& r = v.at(0);
-            THEN("it works")
-            {
-                REQUIRE(generate.first_value == r);
-            }
+            THEN("it works") { REQUIRE(generate.first_value == r); }
         }
         WHEN("at(count) is called")
         {
-            THEN("it raises exception")
-            {
-                CHECK_THROWS_AS(v.at(generate.count), std::out_of_range);
-            }
+            THEN("it raises exception") { CHECK_THROWS_AS(v.at(generate.count), std::out_of_range); }
         }
         WHEN("v[0]")
         {
             value_type& r = v[0];
-            THEN("it is first_value")
-            {
-                REQUIRE(r == generate.first_value);
-            }
+            THEN("it is first_value") { REQUIRE(r == generate.first_value); }
         }
         WHEN("v[count - 1]")
         {
             value_type& r = v[generate.count - 1];
-            THEN("it is last_value")
-            {
-                REQUIRE(r == generate.last_value);
-            }
+            THEN("it is last_value") { REQUIRE(r == generate.last_value); }
         }
         WHEN("front() is called")
         {
             value_type& r = v.front();
-            THEN("it works")
-            {
-                REQUIRE(generate.first_value == r);
-            }
+            THEN("it works") { REQUIRE(generate.first_value == r); }
         }
         WHEN("back() is called")
         {
             value_type& r = v.back();
-            THEN("it works")
-            {
-                REQUIRE(generate.last_value == r);
-            }
+            THEN("it works") { REQUIRE(generate.last_value == r); }
         }
         WHEN("data() is called")
         {
             value_type* p = v.data();
-            THEN("it works")
-            {
-                REQUIRE(generate.first_value == *p);
-            }
+            THEN("it works") { REQUIRE(generate.first_value == *p); }
         }
     }
     GIVEN("A const vector of value_type with 1 item")
@@ -127,57 +92,36 @@ TEMPLATE_LIST_TEST_CASE("access methods", "[vector][access]", pw::test::TestType
         WHEN("at(0) const is called")
         {
             value_type const& r = c.at(0);
-            THEN("it works")
-            {
-                REQUIRE(r == generate.first_value);
-            }
+            THEN("it works") { REQUIRE(r == generate.first_value); }
         }
         WHEN("at(1) const is called")
         {
-            THEN("it raises exception")
-            {
-                CHECK_THROWS_AS(c.at(1), std::out_of_range);
-            }
+            THEN("it raises exception") { CHECK_THROWS_AS(c.at(1), std::out_of_range); }
         }
         WHEN("v[0]")
         {
             value_type const& r = c[0];
-            THEN("it is first_value")
-            {
-                REQUIRE(r == generate.first_value);
-            }
+            THEN("it is first_value") { REQUIRE(r == generate.first_value); }
         }
         WHEN("v[count - 1]")
         {
             value_type const& r = c[generate.count - 1];
-            THEN("it is last_value")
-            {
-                REQUIRE(r == generate.last_value);
-            }
+            THEN("it is last_value") { REQUIRE(r == generate.last_value); }
         }
         WHEN("front() const is called")
         {
             value_type const& r = c.front();
-            THEN("it works")
-            {
-                REQUIRE(r == generate.first_value);
-            }
+            THEN("it works") { REQUIRE(r == generate.first_value); }
         }
         WHEN("back() const is called")
         {
             value_type const& r = c.back();
-            THEN("it works")
-            {
-                REQUIRE(r == generate.last_value);
-            }
+            THEN("it works") { REQUIRE(r == generate.last_value); }
         }
         WHEN("data() const is called")
         {
             value_type const* p = c.data();
-            THEN("it works")
-            {
-                REQUIRE(*p == generate.first_value);
-            }
+            THEN("it works") { REQUIRE(*p == generate.first_value); }
         }
     }
 }

--- a/tests/unit/vector_capacity.t.cpp
+++ b/tests/unit/vector_capacity.t.cpp
@@ -1,4 +1,5 @@
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -24,31 +25,19 @@ TEMPLATE_LIST_TEST_CASE("capacity methods", "[vector][capacity]", pw::test::Test
         Vector v;
         WHEN("empty() is called")
         {
-            THEN("it is true")
-            {
-                REQUIRE(v.empty());
-            }
+            THEN("it is true") { REQUIRE(v.empty()); }
         }
         WHEN("size() is called")
         {
-            THEN("it is 0")
-            {
-                REQUIRE(0 == v.size());
-            }
+            THEN("it is 0") { REQUIRE(0 == v.size()); }
         }
         WHEN("max_size() is called")
         {
-            THEN("it is bigger then 0")
-            {
-                REQUIRE(10000 < v.max_size());
-            }
+            THEN("it is bigger then 0") { REQUIRE(10000 < v.max_size()); }
         }
         WHEN("capacity() is called")
         {
-            THEN("it is 0")
-            {
-                REQUIRE(0 == v.capacity());
-            }
+            THEN("it is 0") { REQUIRE(0 == v.capacity()); }
         }
         GIVEN("and it is const")
         {
@@ -67,61 +56,40 @@ TEMPLATE_LIST_TEST_CASE("capacity methods", "[vector][capacity]", pw::test::Test
         WHEN("empty() is called")
         {
             bool e = v.empty();
-            THEN("it is not empty")
-            {
-                REQUIRE(!e);
-            }
+            THEN("it is not empty") { REQUIRE(!e); }
         }
         WHEN("size() is called")
         {
             size_t s = v.size();
-            THEN("it is the same as count")
-            {
-                REQUIRE(generate.count == s);
-            }
+            THEN("it is the same as count") { REQUIRE(generate.count == s); }
         }
         WHEN("capacity() is called")
         {
             size_t c = v.capacity();
-            THEN("capacity is same")
-            {
-                REQUIRE(generate.count == c);
-            }
+            THEN("capacity is same") { REQUIRE(generate.count == c); }
         }
         WHEN("empty() is called")
         {
             bool e = v.empty();
-            THEN("it is not empty")
-            {
-                REQUIRE(!e);
-            }
+            THEN("it is not empty") { REQUIRE(!e); }
         }
         WHEN("capacity() is called")
         {
             size_t c = v.capacity();
-            THEN("it is at least 1)")
-            {
-                REQUIRE(c >= generate.count);
-            }
+            THEN("it is at least 1)") { REQUIRE(c >= generate.count); }
         }
         WHEN("reserve() is called")
         {
             size_t capacity    = v.capacity();
             size_t newCapacity = capacity + 3;
             v.reserve(newCapacity);
-            THEN("capacity increases")
-            {
-                REQUIRE(newCapacity == v.capacity());
-            }
+            THEN("capacity increases") { REQUIRE(newCapacity == v.capacity()); }
         }
         WHEN("reserve() is called with current capacity")
         {
             size_t capacity = v.capacity();
             v.reserve(capacity);
-            THEN("capacity is unchanged")
-            {
-                REQUIRE(capacity == v.capacity());
-            }
+            THEN("capacity is unchanged") { REQUIRE(capacity == v.capacity()); }
         }
         GIVEN("And extra capacity")
         {

--- a/tests/unit/vector_clear.t.cpp
+++ b/tests/unit/vector_clear.t.cpp
@@ -1,4 +1,5 @@
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -17,10 +18,7 @@ TEMPLATE_LIST_TEST_CASE("clear methods", "[vector][clear]", pw::test::TestTypeLi
         WHEN("clear() is called")
         {
             v.clear();
-            THEN("nothing goes wrong")
-            {
-                REQUIRE(v.empty());
-            }
+            THEN("nothing goes wrong") { REQUIRE(v.empty()); }
         }
     }
     GIVEN("A vector with 5 elements")
@@ -32,23 +30,14 @@ TEMPLATE_LIST_TEST_CASE("clear methods", "[vector][clear]", pw::test::TestTypeLi
         WHEN("clear() is called")
         {
             v.clear();
-            THEN("it is empty")
-            {
-                REQUIRE(v.empty());
-            }
-            THEN("capacity() is same")
-            {
-                REQUIRE(generate.count == v.capacity());
-            }
+            THEN("it is empty") { REQUIRE(v.empty()); }
+            THEN("capacity() is same") { REQUIRE(generate.count == v.capacity()); }
         }
         WHEN("clear() is called then shrink_to_fit()")
         {
             v.clear();
             v.shrink_to_fit();
-            THEN("capacity() is 0")
-            {
-                REQUIRE(0 == v.capacity());
-            }
+            THEN("capacity() is 0") { REQUIRE(0 == v.capacity()); }
         }
     }
 }

--- a/tests/unit/vector_constructor.t.cpp
+++ b/tests/unit/vector_constructor.t.cpp
@@ -112,7 +112,7 @@ TEMPLATE_LIST_TEST_CASE("init-list", "[vector][constructor][init-list]", TestTyp
     std::initializer_list<value_type> initlist = { 1, 2, 5 };
 
     counter = pw::test::DefaultCopyConstructible::getCounter() - init;
-    INFO("counter = " << counter);
+    INFO("counter: " << counter);
     REQUIRE(3 == counter.getOtherConstructor());
     REQUIRE(3 == counter.constructorCount());
     GIVEN("A vector from an init list")
@@ -121,14 +121,8 @@ TEMPLATE_LIST_TEST_CASE("init-list", "[vector][constructor][init-list]", TestTyp
         Vector v { initlist };
         WHEN("nothing is changed")
         {
-            THEN("size() is same")
-            {
-                REQUIRE(3 == v.size());
-            }
-            THEN("capacity() is same")
-            {
-                REQUIRE(v.size() == v.capacity());
-            }
+            THEN("size() is same") { REQUIRE(3 == v.size()); }
+            THEN("capacity() is same") { REQUIRE(v.size() == v.capacity()); }
             THEN("constructors called")
             {
                 counter = pw::test::DefaultCopyConstructible::getCounter() - init;
@@ -141,18 +135,12 @@ TEMPLATE_LIST_TEST_CASE("init-list", "[vector][constructor][init-list]", TestTyp
             Vector v2;
             v2.push_back(pw::test::DefaultCopyConstructible(1));
             v2 = v;
-            THEN("They are the same")
-            {
-                REQUIRE(v == v2);
-            }
+            THEN("They are the same") { REQUIRE(v == v2); }
         }
         WHEN("copy construct")
         {
             Vector v2(v);
-            THEN("They are the same")
-            {
-                REQUIRE(v == v2);
-            }
+            THEN("They are the same") { REQUIRE(v == v2); }
         }
     }
 }

--- a/tests/unit/vector_constructor.t.cpp
+++ b/tests/unit/vector_constructor.t.cpp
@@ -1,6 +1,7 @@
 #include <pw/vector>
 #include <test_defaultcopyconstructible.h>
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <tuple>
 #include <vector>
@@ -29,20 +30,14 @@ TEMPLATE_LIST_TEST_CASE("count constructors in vector", "[vector][constructor]",
         WHEN("Nothing was called")
         {
             counter = pw::test::DefaultCopyConstructible::getCounter() - init;
-            THEN("Nothing was constructed")
-            {
-                REQUIRE(counter.zero());
-            }
+            THEN("Nothing was constructed") { REQUIRE(counter.zero()); }
         }
         WHEN("reserve() is increased")
         {
             counter = pw::test::DefaultCopyConstructible::getCounter();
             v.reserve(5);
             counter = pw::test::DefaultCopyConstructible::getCounter() - counter;
-            THEN("copy constructor not called")
-            {
-                REQUIRE(counter.zero());
-            }
+            THEN("copy constructor not called") { REQUIRE(counter.zero()); }
         }
     }
     GIVEN("A vector with 5 elements")
@@ -54,19 +49,13 @@ TEMPLATE_LIST_TEST_CASE("count constructors in vector", "[vector][constructor]",
         WHEN("copy constructor is called")
         {
             Vector c(v);
-            THEN("two vectors are same")
-            {
-                REQUIRE(pw::equal(v.begin(), v.end(), c.begin(), c.end()));
-            }
+            THEN("two vectors are same") { REQUIRE(pw::equal(v.begin(), v.end(), c.begin(), c.end())); }
         }
         WHEN("move constructor is called")
         {
             Vector c(v);
             Vector d(pw::move(v));
-            THEN("two vectors are same")
-            {
-                REQUIRE(pw::equal(c.begin(), c.end(), d.begin(), d.end()));
-            }
+            THEN("two vectors are same") { REQUIRE(pw::equal(c.begin(), c.end(), d.begin(), d.end())); }
         }
         WHEN("move constructor is called")
         {

--- a/tests/unit/vector_emplace_back.t.cpp
+++ b/tests/unit/vector_emplace_back.t.cpp
@@ -54,10 +54,7 @@ TEMPLATE_LIST_TEST_CASE("emplace_back() with EmplaceMoveConstructible",
         {
             v.emplace_back(3, 4);
             counter = pw::test::EmplaceMoveConstructible::getCounter() - init;
-            THEN("size() is 1")
-            {
-                REQUIRE(1 == v.size());
-            }
+            THEN("size() is 1") { REQUIRE(1 == v.size()); }
             THEN("element has correct values")
             {
                 REQUIRE(3 == v.front().value());
@@ -81,10 +78,7 @@ TEMPLATE_LIST_TEST_CASE("emplace_back() with EmplaceMoveConstructible",
         {
             v.emplace_back(13, 14);
             counter = pw::test::EmplaceMoveConstructible::getCounter() - init;
-            THEN("size() is 4")
-            {
-                REQUIRE(4 == v.size());
-            }
+            THEN("size() is 4") { REQUIRE(4 == v.size()); }
             THEN("element has correct values")
             {
                 REQUIRE(1 == v.front().value());
@@ -94,7 +88,7 @@ TEMPLATE_LIST_TEST_CASE("emplace_back() with EmplaceMoveConstructible",
             }
             THEN("other constructed, not copy or move")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(1 == counter.getOtherConstructor());
                 REQUIRE(3 == counter.getMoveConstructor());
                 REQUIRE(4 == counter.constructorCount());

--- a/tests/unit/vector_erase.t.cpp
+++ b/tests/unit/vector_erase.t.cpp
@@ -1,4 +1,5 @@
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -18,10 +19,7 @@ TEMPLATE_LIST_TEST_CASE("Test erase", "[vector][erase]", pw::test::TestTypeList)
         WHEN("erase(begin,end)")
         {
             iter = v.erase(v.begin(), v.end());
-            THEN("nothing is changed")
-            {
-                REQUIRE(v.empty());
-            }
+            THEN("nothing is changed") { REQUIRE(v.empty()); }
             THEN("begin() is same as returned iterator")
             {
                 REQUIRE(v.begin() == iter);

--- a/tests/unit/vector_insert.t.cpp
+++ b/tests/unit/vector_insert.t.cpp
@@ -7,6 +7,9 @@
 
 #include <catch2/catch.hpp>
 
+#include <iostream>
+#include <iterator>
+
 /*
  * Type requirements:
  * - insert(const_iterator pos, const T& value): CopyAssignable and CopyInsertable
@@ -18,7 +21,7 @@
  * Exceptions:
  * - yex
  */
-TEMPLATE_LIST_TEST_CASE("Test insert", "[vector][insert]", pw::test::TestTypeList)
+TEMPLATE_LIST_TEST_CASE("Test insert(pos, value)", "[vector][insert]", pw::test::TestTypeList)
 {
     using Vector     = TestType;
     using value_type = typename Vector::value_type;
@@ -26,12 +29,22 @@ TEMPLATE_LIST_TEST_CASE("Test insert", "[vector][insert]", pw::test::TestTypeLis
     {
         Vector v;
 
-        WHEN("insert() is called")
+        WHEN("insert(begin, value) is called")
         {
             typename Vector::iterator iter;
             value_type                value;
             pw::test::permute(value, 3);
             iter = v.insert(v.begin(), value);
+            THEN("size() is increased") { REQUIRE(1 == v.size()); }
+            THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("at(0) returns same value") { REQUIRE(value == v.at(0)); }
+        }
+        WHEN("insert(end, value) is called")
+        {
+            typename Vector::iterator iter;
+            value_type                value;
+            pw::test::permute(value, 3);
+            iter = v.insert(v.end(), value);
             THEN("size() is increased") { REQUIRE(1 == v.size()); }
             THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
             THEN("at(0) returns same value") { REQUIRE(value == v.at(0)); }
@@ -186,20 +199,20 @@ TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert][test]
 {
     using Vector     = TestType;
     using value_type = typename Vector::value_type;
-    // GIVEN("an empty vector")
-    // {
-    //     Vector                   v;
-    //     pw::test::Values<Vector> generate(5);
+    GIVEN("an empty vector")
+    {
+        Vector                   v;
+        pw::test::Values<Vector> generate(5);
 
-    //     WHEN("insert(begin, first, last) is called without capacity")
-    //     {
-    //         typename Vector::iterator iter;
-    //         iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
-    //         THEN("size() is increased") { REQUIRE(generate.values.size() == v.size()); }
-    //         THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
-    //         THEN("front() returns same value") { REQUIRE(generate.first_value == v.front()); }
-    //     }
-    // }
+        WHEN("insert(begin, first, last) is called without capacity")
+        {
+            typename Vector::iterator iter;
+            iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
+            THEN("size() is increased") { REQUIRE(generate.values.size() == v.size()); }
+            THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("front() returns same value") { REQUIRE(generate.first_value == v.front()); }
+        }
+    }
     GIVEN("A vector with 5 elements")
     {
         pw::test::Values<Vector> generate(5);
@@ -225,9 +238,12 @@ TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert][test]
         }
         WHEN("insert(begin, first, last) is called with enough capacity")
         {
-            typename Vector::iterator iter;
+            typename Vector::size_type space;
+            typename Vector::iterator  iter;
             v.reserve(v.size() + generate.values.size());
-            iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
+            space = v.capacity();
+            iter  = v.insert(v.begin(), generate.values.begin(), generate.values.end());
+            THEN("capacity() is unchanged") { REQUIRE(space == v.capacity()); }
             THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
             THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
             THEN("inserted values match") { REQUIRE(generate.first_value == v[0]); }

--- a/tests/unit/vector_insert.t.cpp
+++ b/tests/unit/vector_insert.t.cpp
@@ -3,6 +3,7 @@
 #include <test_permute.h>
 #include <test_same.h>
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -237,7 +238,7 @@ TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert][test]
             v.reserve(v.size() + generate.values.size());
             iter = v.insert(v.end(), generate.values.begin(), generate.values.end());
             THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
-            THEN("end() is same as returned iterator") { REQUIRE(v.end() == iter); }
+            THEN("iter is at start of insert") { REQUIRE(v.begin() + generate.values.size() == iter); }
             THEN("back() returns same value") { REQUIRE(generate.last_value == v.back()); }
         }
     }

--- a/tests/unit/vector_insert.t.cpp
+++ b/tests/unit/vector_insert.t.cpp
@@ -181,71 +181,64 @@ TEMPLATE_LIST_TEST_CASE("Test insert(pos, count, value)", "[vector][insert]", pw
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert]", pw::test::TestTypeList)
+TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert][test]", pw::test::TestTypeList)
 {
     using Vector     = TestType;
     using value_type = typename Vector::value_type;
-    GIVEN("an empty vector")
-    {
-        Vector                   v;
-        pw::test::Values<Vector> generate(5);
+    // GIVEN("an empty vector")
+    // {
+    //     Vector                   v;
+    //     pw::test::Values<Vector> generate(5);
 
-        WHEN("insert(begin, first, last) is called")
-        {
-            typename Vector::iterator iter;
-            iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
-            THEN("size() is increased")
-            {
-                REQUIRE(generate.values.size() == v.size());
-            }
-            THEN("begin() is same as returned iterator")
-            {
-                REQUIRE(v.begin() == iter);
-            }
-            THEN("front() returns same value")
-            {
-                REQUIRE(generate.first_value == v.front());
-            }
-        }
-    }
+    //     WHEN("insert(begin, first, last) is called without capacity")
+    //     {
+    //         typename Vector::iterator iter;
+    //         iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
+    //         THEN("size() is increased") { REQUIRE(generate.values.size() == v.size()); }
+    //         THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+    //         THEN("front() returns same value") { REQUIRE(generate.first_value == v.front()); }
+    //     }
+    // }
     GIVEN("A vector with 5 elements")
     {
         pw::test::Values<Vector> generate(5);
         Vector                   v(generate.values);
-
-        WHEN("insert(begin, first, last) is called")
+        WHEN("insert(begin, first, last) is called without capacity")
         {
             typename Vector::iterator iter;
             iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
-            THEN("size() is increased")
-            {
-                REQUIRE(2 * generate.values.size() == v.size());
-            }
-            THEN("begin() is same as returned iterator")
-            {
-                REQUIRE(v.begin() == iter);
-            }
-            THEN("front() returns same value")
-            {
-                REQUIRE(generate.first_value == v.front());
-            }
+            THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
+            THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("front() returns same value") { REQUIRE(generate.first_value == v.front()); }
         }
-        WHEN("insert(end, first, last) is called")
+        WHEN("insert(end, first, last) is called without capacity")
         {
             typename Vector::iterator iter;
             iter = v.insert(v.end(), generate.values.begin(), generate.values.end());
-            THEN("size() is increased")
-            {
-                REQUIRE(2 * generate.values.size() == v.size());
-            }
+            THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
             THEN("begin() is same as returned iterator")
             {
                 REQUIRE(pw::next(v.begin(), generate.values.size()) == iter);
             }
-            THEN("front() returns same value")
-            {
-                REQUIRE(generate.last_value == v.back());
-            }
+            THEN("front() returns same value") { REQUIRE(generate.last_value == v.back()); }
+        }
+        WHEN("insert(begin, first, last) is called with enough capacity")
+        {
+            typename Vector::iterator iter;
+            v.reserve(v.size() + generate.values.size());
+            iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
+            THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
+            THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("back() returns same value") { REQUIRE(generate.last_value == v.back()); }
+        }
+        WHEN("insert(end, first, last) is called with enough capacity")
+        {
+            typename Vector::iterator iter;
+            v.reserve(v.size() + generate.values.size());
+            iter = v.insert(v.end(), generate.values.begin(), generate.values.end());
+            THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
+            THEN("end() is same as returned iterator") { REQUIRE(v.end() == iter); }
+            THEN("back() returns same value") { REQUIRE(generate.last_value == v.back()); }
         }
     }
 }

--- a/tests/unit/vector_insert.t.cpp
+++ b/tests/unit/vector_insert.t.cpp
@@ -230,6 +230,7 @@ TEMPLATE_LIST_TEST_CASE("Test insert(pos, first, last)", "[vector][insert][test]
             iter = v.insert(v.begin(), generate.values.begin(), generate.values.end());
             THEN("size() is increased") { REQUIRE(2 * generate.values.size() == v.size()); }
             THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("inserted values match") { REQUIRE(generate.first_value == v[0]); }
             THEN("back() returns same value") { REQUIRE(generate.last_value == v.back()); }
         }
         WHEN("insert(end, first, last) is called with enough capacity")

--- a/tests/unit/vector_insert.t.cpp
+++ b/tests/unit/vector_insert.t.cpp
@@ -31,18 +31,9 @@ TEMPLATE_LIST_TEST_CASE("Test insert", "[vector][insert]", pw::test::TestTypeLis
             value_type                value;
             pw::test::permute(value, 3);
             iter = v.insert(v.begin(), value);
-            THEN("size() is increased")
-            {
-                REQUIRE(1 == v.size());
-            }
-            THEN("begin() is same as returned iterator")
-            {
-                REQUIRE(v.begin() == iter);
-            }
-            THEN("at(0) returns same value")
-            {
-                REQUIRE(value == v.at(0));
-            }
+            THEN("size() is increased") { REQUIRE(1 == v.size()); }
+            THEN("begin() is same as returned iterator") { REQUIRE(v.begin() == iter); }
+            THEN("at(0) returns same value") { REQUIRE(value == v.at(0)); }
         }
     }
     GIVEN("A vector with 5 elements")
@@ -53,7 +44,14 @@ TEMPLATE_LIST_TEST_CASE("Test insert", "[vector][insert]", pw::test::TestTypeLis
         value_type                value;
         typename Vector::iterator where;
 
-        Vector v(generate.values);
+        WHEN("insert() at begin")
+        {
+            generate.values.insert(generate.values.begin(), value);
+            THEN("size() is bigger") { REQUIRE(generate.values.size() == generate.count + 1); }
+            THEN("inserted value at front") { REQUIRE(value == generate.values.front()); }
+            THEN("moved to 1 position") { REQUIRE(generate.first_value == generate.values[1]); }
+            THEN("last is still last") { REQUIRE(generate.last_value == generate.values.back()); }
+        }
     }
 }
 

--- a/tests/unit/vector_pop_back.t.cpp
+++ b/tests/unit/vector_pop_back.t.cpp
@@ -1,4 +1,5 @@
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 
@@ -21,14 +22,8 @@ TEMPLATE_LIST_TEST_CASE("pop_back()", "[vector][pop_back]", pw::test::TestTypeLi
         WHEN("pop_back() is called")
         {
             v.pop_back();
-            THEN("size is 1 smaller")
-            {
-                REQUIRE(generate.count == v.size() + 1);
-            }
-            THEN("capacity is unchanged")
-            {
-                REQUIRE(capacity == v.capacity());
-            }
+            THEN("size is 1 smaller") { REQUIRE(generate.count == v.size() + 1); }
+            THEN("capacity is unchanged") { REQUIRE(capacity == v.capacity()); }
         }
     }
     GIVEN("A vector with 1 element")
@@ -41,18 +36,9 @@ TEMPLATE_LIST_TEST_CASE("pop_back()", "[vector][pop_back]", pw::test::TestTypeLi
         WHEN("pop_back() is called")
         {
             v.pop_back();
-            THEN("size is 1 smaller")
-            {
-                REQUIRE(generate.count == v.size() + 1);
-            }
-            THEN("it is empty")
-            {
-                REQUIRE(v.empty());
-            }
-            THEN("capacity is unchanged")
-            {
-                REQUIRE(capacity == v.capacity());
-            }
+            THEN("size is 1 smaller") { REQUIRE(generate.count == v.size() + 1); }
+            THEN("it is empty") { REQUIRE(v.empty()); }
+            THEN("capacity is unchanged") { REQUIRE(capacity == v.capacity()); }
         }
     }
 }

--- a/tests/unit/vector_push_back.t.cpp
+++ b/tests/unit/vector_push_back.t.cpp
@@ -127,12 +127,12 @@ SCENARIO("push_back() op counts", "[vector][push_back][optracker]")
             counter = pw::test::DefaultCopyConstructible::getCounter() - counter;
             THEN("Move constructed existing items")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(generate.count == counter.getMoveConstructor());
             }
             THEN("Copy constructed new item")
             {
-                INFO("counter = " << counter);
+                INFO("counter: " << counter);
                 REQUIRE(1 == counter.getCopyConstructor());
             }
         }

--- a/tests/unit/vector_push_back.t.cpp
+++ b/tests/unit/vector_push_back.t.cpp
@@ -2,6 +2,7 @@
 #include <test_defaultcopyconstructible.h>
 #include <test_permute.h>
 #include <test_testtype.h>
+#include <test_values.h>
 
 #include <catch2/catch.hpp>
 

--- a/tests/unit/vector_push_back.t.cpp
+++ b/tests/unit/vector_push_back.t.cpp
@@ -126,9 +126,14 @@ SCENARIO("push_back() op counts", "[vector][push_back][optracker]")
             counter = pw::test::DefaultCopyConstructible::getCounter() - counter;
             THEN("Move constructed existing items")
             {
+                INFO("counter = " << counter);
                 REQUIRE(generate.count == counter.getMoveConstructor());
             }
-            THEN("Copy constructed new item") { REQUIRE(1 == counter.getCopyConstructor()); }
+            THEN("Copy constructed new item")
+            {
+                INFO("counter = " << counter);
+                REQUIRE(1 == counter.getCopyConstructor());
+            }
         }
     }
     counter = pw::test::DefaultCopyConstructible::getCounter() - init;

--- a/tests/unit/vector_resize.t.cpp
+++ b/tests/unit/vector_resize.t.cpp
@@ -149,6 +149,7 @@ SCENARIO("resize() op counts", "[vector][resize][optracker]")
             counter = pw::test::DefaultCopyConstructible::getCounter() - counter;
             THEN("default constructed count times")
             {
+                INFO("counter: " << counter);
                 REQUIRE(count == counter.getDefaultConstructor());
                 REQUIRE(counter.getDefaultConstructor() == counter.constructorCount());
                 REQUIRE(counter.allCount() == count);


### PR DESCRIPTION
Removes some methods from `Storage` as they weren't really clear how they should be used.

- Removed various `Storage` copy constructors
- `Storage::move()`: Removed
- `Storage::resize()`: Removed
- `Storage::split()`: Removed
- `Storage::cons()`: Removed
- `Stoage::copyto()`: New.  method template that acts like `moveto()` but handles uninitialized memory
